### PR TITLE
Added GLFW and GLM Libraries into CMake implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,10 +9,9 @@ set(GLFW_BUILD_TESTS OFF CACHE BOOL "" FORCE)
 set(GLFW_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
 
 find_package(glm 0.9.8 REQUIRED)
-include_directories(${GLM_INCLUDE_DIRS})
+include_directories(${GLM_INCLUDE_DIRS} "Include Files")
 
-file(GLOB_RECURSE "INCLUDES" "*.h")
-file(GLOB_RECURSE "SOURCES" "*.cpp" "*.h")
+file(GLOB_RECURSE "SOURCES" "Source Files/*.cpp")
 
-add_executable(Soul_Engine ${SOURCES} ${INCLUDES})
+add_executable(Soul_Engine ${SOURCES})
 target_link_libraries(Soul_Engine glfw)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,16 @@ project(Soul_Engine)
 
 set(CMAKE_CXX_STANDARD 11)
 
+add_subdirectory(Libraries/glfw-3.2.1)
+set(GLFW_BUILD_DOCS OFF CACHE BOOL "" FORCE)
+set(GLFW_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+set(GLFW_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+
+find_package(glm 0.9.8 REQUIRED)
+include_directories(${GLM_INCLUDE_DIRS})
+
 file(GLOB_RECURSE "INCLUDES" "*.h")
 file(GLOB_RECURSE "SOURCES" "*.cpp" "*.h")
 
 add_executable(Soul_Engine ${SOURCES} ${INCLUDES})
+target_link_libraries(Soul_Engine glfw)


### PR DESCRIPTION
Besides the basic adding library stuff, I had to make some changes to my initial CMake implementation. I found that some test stuff in the GLM library was accidentally being included because I messed up in the Glob Recurse and it was grabbing things it shouldn't be - that's why even some stuff that doesn't necessarily have to do with libraries is changed.