### PR TITLE
Change local time to UTC

### DIFF
--- a/Source Files/Utility/Logger.cpp
+++ b/Source Files/Utility/Logger.cpp
@@ -62,7 +62,7 @@ namespace Logger {
 		int line;
 		line = 7;
 		char* str;
-		time = pt::to_iso_string(pt::second_clock::local_time());
+		time = pt::to_iso_string(pt::second_clock::universal_time());
 		log << time << std::endl;
 		detail::WriteInfo(log, file, line);
 		log.close();

--- a/Test/LoggerTest/Source.cpp
+++ b/Test/LoggerTest/Source.cpp
@@ -7,7 +7,7 @@ int main()
 	namespace pt = boost::posix_time;
 	std::string line;
 	std::string time;
-	time = pt::to_iso_string(pt::second_clock::local_time());
+	time = pt::to_iso_string(pt::second_clock::universal_time());
 	Logger::WriteFile();
 	std::ifstream file("Engine.log");
 	std::getline(file, line);


### PR DESCRIPTION
Make sure that the time printed is in UTC, so Windows PCs can hang out with Unix-based PCs without causing confusion.