### PR TITLE
Add monitor abstraction for #205

### DIFF
--- a/Source/Display/Window/CMakeLists.txt
+++ b/Source/Display/Window/CMakeLists.txt
@@ -10,10 +10,15 @@ target_sources(${PROJECT_NAME}
         Modules/GLFW/GLFWWindowBackend.h
         Modules/GLFW/GLFWWindow.cpp
         Modules/GLFW/GLFWWindow.h
+	Modules/GLFW/GLFWMonitor.cpp
+	Modules/GLFW/GLFWMonitor.h
         Modules/Mock/MockWindowBackend.cpp
         Modules/Mock/MockWindowBackend.h
         Modules/Mock/MockWindow.cpp
         Modules/Mock/MockWindow.h
+	Modules/Mock/MockMonitor.cpp
+	Modules/Mock/MockMonitor.h
         Window.cpp
         Window.h
+	Monitor.h
 )

--- a/Source/Display/Window/Modules/GLFW/GLFWMonitor.cpp
+++ b/Source/Display/Window/Modules/GLFW/GLFWMonitor.cpp
@@ -1,0 +1,47 @@
+#include "GLFWMonitor.h"
+
+#include <GLFW/glfw3.h>
+
+GLFWMonitor::GLFWMonitor(GLFWmonitor* monitor)
+	: monitor_(monitor),
+	videoMode_(glfwGetVideoMode(monitor)),
+	name_(glfwGetMonitorName(monitor))
+{
+}
+
+GLFWMonitor::~GLFWMonitor()
+{
+}
+
+void GLFWMonitor::Scale(float& xscale, float& yscale) const
+{
+	glfwGetMonitorContentScale(monitor_, &xscale, &yscale);
+}
+
+void GLFWMonitor::Position(int& xpos, int& ypos) const
+{
+	glfwGetMonitorPos(monitor_, &xpos, &ypos);
+}
+
+void GLFWMonitor::Size(int& width, int& height) const
+{
+	width = videoMode_->width;
+	height = videoMode_->height;
+}
+
+void GLFWMonitor::ColorBits(int& red, int& green, int& blue) const
+{
+	red = videoMode_->redBits;
+	green = videoMode_->greenBits;
+	blue = videoMode_->blueBits;
+}
+
+void GLFWMonitor::RefreshRate(int& refreshRate) const
+{
+	refreshRate = videoMode_->refreshRate;
+}
+
+std::string GLFWMonitor::Name() const
+{
+	return std::string(name_);
+}

--- a/Source/Display/Window/Modules/GLFW/GLFWMonitor.h
+++ b/Source/Display/Window/Modules/GLFW/GLFWMonitor.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "Display/Window/Monitor.h"
+#include "Core/Utility/ID/TypeID.h"
+
+class GLFWWindow;
+struct GLFWmonitor;
+struct GLFWvidmode;
+
+class GLFWMonitor final : public Monitor, TypeID<GLFWMonitor> {
+
+public:
+	friend class GLFWWindow;
+
+	GLFWMonitor(GLFWmonitor*);
+	~GLFWMonitor() override;
+
+	void Scale(float&, float&) const;
+
+	void Position(int&, int&) const;
+
+	void Size(int&, int&) const;
+	void ColorBits(int&, int&, int&) const;
+	void RefreshRate(int&) const;
+
+	std::string Name() const;
+
+private:
+
+	GLFWmonitor* monitor_;
+
+	const GLFWvidmode* videoMode_;
+	const char* name_;
+};

--- a/Source/Display/Window/Modules/GLFW/GLFWWindow.cpp
+++ b/Source/Display/Window/Modules/GLFW/GLFWWindow.cpp
@@ -1,5 +1,6 @@
 #include "GLFWWindow.h"
 
+#include "GLFWMonitor.h"
 #include "Rasterer/RasterModule.h"
 #include "Rasterer/Modules/Vulkan/VulkanRasterBackend.h"
 
@@ -8,19 +9,20 @@
 #include <any>
 
 GLFWWindow::GLFWWindow(const WindowParameters& params,
-	GLFWmonitor* monitor,
+	GLFWMonitor& monitor,
 	std::shared_ptr<RasterModule> rasterModule,
 	bool master):
 	Window(params),
 	rasterModule_(rasterModule), master_(master)
 {
+	int redBits, greenBits, blueBits, refreshRate;
+	monitor.ColorBits(redBits, greenBits, blueBits);
+	monitor.RefreshRate(refreshRate);
 
-	const GLFWvidmode* mode = glfwGetVideoMode(monitor);
-
-	glfwWindowHint(GLFW_RED_BITS, mode->redBits);
-	glfwWindowHint(GLFW_GREEN_BITS, mode->greenBits);
-	glfwWindowHint(GLFW_BLUE_BITS, mode->blueBits);
-	glfwWindowHint(GLFW_REFRESH_RATE, mode->refreshRate);
+	glfwWindowHint(GLFW_RED_BITS, redBits);
+	glfwWindowHint(GLFW_GREEN_BITS, greenBits);
+	glfwWindowHint(GLFW_BLUE_BITS, blueBits);
+	glfwWindowHint(GLFW_REFRESH_RATE, refreshRate);
 
 	// TODO Cleanup and implement more features
 
@@ -34,7 +36,7 @@ GLFWWindow::GLFWWindow(const WindowParameters& params,
 		glfwWindowHint(GLFW_RESIZABLE, false);
 		glfwWindowHint(GLFW_DECORATED, false);
 
-		fullscreenMonitor = monitor;
+		fullscreenMonitor = monitor.monitor_;
 	}
 	else if (windowParams_.type == WindowType::WINDOWED) {
 

--- a/Source/Display/Window/Modules/GLFW/GLFWWindow.h
+++ b/Source/Display/Window/Modules/GLFW/GLFWWindow.h
@@ -7,6 +7,7 @@
 
 struct GLFWmonitor;
 struct GLFWwindow;
+class GLFWMonitor;
 class RasterModule;
 class RasterBackend;
 
@@ -14,7 +15,7 @@ class GLFWWindow final : public Window, TypeID<GLFWWindow> {
 
 public:
 
-	GLFWWindow(const WindowParameters&, GLFWmonitor*, std::shared_ptr<RasterModule>, bool);
+	GLFWWindow(const WindowParameters&, GLFWMonitor&, std::shared_ptr<RasterModule>, bool);
 	~GLFWWindow() override;
 
 	GLFWWindow(const GLFWWindow &) = delete;

--- a/Source/Display/Window/Modules/GLFW/GLFWWindowBackend.cpp
+++ b/Source/Display/Window/Modules/GLFW/GLFWWindowBackend.cpp
@@ -2,6 +2,7 @@
 
 #include "WindowParameters.h"
 #include "GLFWWindow.h"
+#include "GLFWMonitor.h"
 #include "Core/Utility/Exception/Exception.h"
 #include "Display/Input/Modules/GLFW/GLFWInputBackend.h"
 
@@ -28,13 +29,12 @@ GLFWWindowBackend::GLFWWindowBackend(std::shared_ptr<InputModule>& inputModule):
 	// Raster API specific checks
 	assert(glfwVulkanSupported());
 
-	// TODO: std::span
 	int monitorCount;
 	GLFWmonitor** tempMonitors = glfwGetMonitors(&monitorCount);
 	monitors_.reserve(monitorCount);
 
 	for (auto i = 0; i < monitorCount; ++i) {
-		monitors_.push_back(tempMonitors[i]);
+		monitors_.emplace_back(tempMonitors[i]);
 	}
 
 	// Global GLFW window settings
@@ -75,7 +75,7 @@ void GLFWWindowBackend::CreateWindow(const WindowParameters& params,
 
 	assert(params.monitor < static_cast<int>(monitors_.size()));
 
-	GLFWmonitor* monitor = monitors_[params.monitor];
+	GLFWMonitor& monitor = monitors_[params.monitor];
 
 
 	std::unique_ptr<GLFWWindow> window =

--- a/Source/Display/Window/Modules/GLFW/GLFWWindowBackend.cpp
+++ b/Source/Display/Window/Modules/GLFW/GLFWWindowBackend.cpp
@@ -29,6 +29,7 @@ GLFWWindowBackend::GLFWWindowBackend(std::shared_ptr<InputModule>& inputModule):
 	// Raster API specific checks
 	assert(glfwVulkanSupported());
 
+	// TODO: std::span
 	int monitorCount;
 	GLFWmonitor** tempMonitors = glfwGetMonitors(&monitorCount);
 	monitors_.reserve(monitorCount);

--- a/Source/Display/Window/Modules/GLFW/GLFWWindowBackend.h
+++ b/Source/Display/Window/Modules/GLFW/GLFWWindowBackend.h
@@ -4,9 +4,9 @@
 
 #include <unordered_map>
 
-struct GLFWmonitor;
 struct GLFWwindow;
 class GLFWWindow;
+class GLFWMonitor;
 class WindowParameters;
 class VulkanRasterBackend;
 class GLFWInputBackend;
@@ -48,8 +48,7 @@ private:
 
 	GLFWWindow& GetWindow(GLFWwindow*);
 
-	//TODO: Replace with std::span as GLFW owns and manages the monitors - C++20
-	std::vector<GLFWmonitor*> monitors_;
+	std::vector<GLFWMonitor> monitors_;
 	std::unordered_map<GLFWwindow*, std::unique_ptr<GLFWWindow>> windows_;
 
 	// Luxery of having the Input system be GLFW

--- a/Source/Display/Window/Modules/Mock/MockMonitor.cpp
+++ b/Source/Display/Window/Modules/Mock/MockMonitor.cpp
@@ -1,0 +1,49 @@
+#include "MockMonitor.h"
+
+#include "Core/Utility/Exception/Exception.h"
+
+MockMonitor::MockMonitor()
+{
+}
+
+void MockMonitor::Scale(float&, float&) const
+{
+
+	throw NotImplemented();
+
+}
+
+void MockMonitor::Position(int&, int&) const
+{
+
+	throw NotImplemented();
+
+}
+
+void MockMonitor::Size(int&, int&) const
+{
+
+	throw NotImplemented();
+
+}
+
+void MockMonitor::ColorBits(int&, int&, int&) const
+{
+
+	throw NotImplemented();
+
+}
+
+void MockMonitor::RefreshRate(int&) const
+{
+
+	throw NotImplemented();
+
+}
+
+std::string MockMonitor::Name() const
+{
+
+	throw NotImplemented();
+
+}

--- a/Source/Display/Window/Modules/Mock/MockMonitor.h
+++ b/Source/Display/Window/Modules/Mock/MockMonitor.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "Display/Window/Monitor.h"
+#include <string>
+
+class MockMonitor : public Monitor
+{
+
+public:
+
+	MockMonitor();
+	virtual ~MockMonitor() = default;
+
+	void Scale(float& xscale, float& yscale) const;
+	
+	void Position(int& xpos, int& ypos) const;
+
+	void Size(int& width, int& height) const;
+	void ColorBits(int& red, int& blue, int& green) const;
+	void RefreshRate(int& refreshRate) const;
+
+	std::string Name() const;
+
+};

--- a/Source/Display/Window/Modules/Mock/MockWindowBackend.cpp
+++ b/Source/Display/Window/Modules/Mock/MockWindowBackend.cpp
@@ -42,6 +42,6 @@ Window& MockWindowBackend::GetWindow()
 
 	throw NotImplemented();
 
-	return MockWindow();
+//	return MockWindow();
 
 }

--- a/Source/Display/Window/Monitor.h
+++ b/Source/Display/Window/Monitor.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <string>
+
+class Monitor
+{
+
+public:
+
+	Monitor() {}
+	virtual ~Monitor() = default;
+
+	Monitor(const Monitor &) = default;
+	Monitor(Monitor &&) noexcept = default;
+
+	Monitor& operator=(const Monitor &) = delete;
+	Monitor& operator=(Monitor &&) noexcept = default;
+
+	void Scale(float&, float&) const = delete;
+	
+	void Position(int&, int&) const = delete;
+
+	void Size(int&, int&) const = delete;
+	void ColorBits(int&, int&, int&) const = delete;
+	void RefreshRate(int&) const = delete;
+
+	std::string Name() const = delete;
+
+};


### PR DESCRIPTION
Creates a general `Monitor.h` interface and a GLFW monitor implementation.  GLFW windows are able to access the raw monitor pointer directly to call glfw functions, otherwise monitor information must be accessed using the public-facing API designed to mirror the design of the glfw API.